### PR TITLE
Ignore .idea/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# JetBrains IDEs
+.idea/


### PR DESCRIPTION
Adds a `.gitignore` (the repo had none) covering WebStorm's `.idea/` directory, which was showing up as untracked and triggering a warning on every `gh pr create`.

The directory was never committed, so no history change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xs8wWrAJCALFQn8CSmcWuU