### PR TITLE
Add a PHI warning for hosted DICOM viewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,13 +359,36 @@ DICOM punishes assumptions. These are the assumptions it punishes most often.
 - [3D Slicer](https://www.slicer.org/) - Research imaging platform — segmentation, registration, a huge
   extension library, and a real DICOM database underneath.
 - [VolView](https://github.com/Kitware/VolView) - Kitware's browser-based 3D volume renderer and
-  annotator. Data stays client-side.
+  annotator. Processes data in the browser; ships opt-out Sentry crash reporting (see the note below).
+  [Hosted demo](https://volview.kitware.app/)
 - [DWV](https://github.com/ivmartel/dwv) - Small, dependency-light JS viewer. The good embedding and
   teaching option.
 - [Horos](https://horosproject.org/) - The macOS open-source viewer (an OsiriX fork; OsiriX itself went
   commercial). Now supports Apple Silicon.
 - [MicroDicom](https://www.microdicom.com/) - Capable Windows viewer, free for non-commercial use.
   (freeware, not open source)
+
+> **The hosted viewers here clear a bar the HL7 web tools don't — verify anyway.** OHIF, DWV, and
+> VolView all publish their source, so "it runs in your browser" is a claim you can audit instead of
+> one you have to take on faith. That is the difference between them and
+> [the hosted HL7 tools](#tools-and-validators), and it is why this note is shorter and less alarmed
+> than that one. Read it anyway, because DICOM leaks differently than HL7 does:
+>
+> - **You cannot eyeball a DICOM for PHI.** You can read a `PID` segment before you paste it. You
+>   cannot see the patient name burned into an ultrasound frame, or sitting in a private tag, or
+>   embedded in an SR. The file you think is clean usually isn't.
+> - **The filename is PHI too.** VolView's crash reporting is on by default (toggleable in settings,
+>   no session replay, source is public — this is disclosed, not sneaky). But
+>   `SMITH_JOHN_20240115.dcm` in an error report is a disclosure whether or not a single pixel moved.
+> - **"Client-side" stops being true at the codec boundary.** JPEG 2000 and JPEG-LS are miserable
+>   in-browser, so some viewers quietly round-trip to a server to transcode — see
+>   [the transfer-syntax note](#dicom-notes-and-tips). That is an upload, whatever the front page says.
+> - **The risky control is the URL bar, not the file picker.** Pointing a hosted viewer at your
+>   institution's DICOMweb endpoint hands a third-party page your archive *and* your credentials.
+>   Pushing a study to a public demo archive publishes it.
+>
+> There is no shortage of local viewers above. Use one for real studies, and keep
+> [synthetic data](#dicom-test-data) for anything hosted.
 
 ## DICOM Tools and Utilities
 


### PR DESCRIPTION
Three DICOM entries are hosted: **OHIF** (`viewer.ohif.org`), **DWV** (`ivmartel.github.io/dwv`), and **VolView** (`volview.kitware.app`).

## Why this isn't a copy of the HL7 warning

All three publish their source. That is precisely the test `hl7inspector.com` and `hl7viewer.com` fail, and the HL7 warning is built around it. Reusing that text verbatim would assert something false about these tools and would punish the ones doing it right — so this note says so explicitly and then covers the risks that *are* DICOM-specific.

## What the audit found

I checked all three for analytics. DWV and OHIF have none in `package.json`. **VolView ships `@sentry/vue`.** Reading `src/utils/errorReporting.ts`:

- Initialized by default whenever `VITE_SENTRY_DSN` is set
- Opt-out toggle, persisted to `localStorage`
- No `Replay` integration, no `sendDefaultPii`

So it is nothing like session replay, and it's disclosed rather than hidden. But crash reports still carry breadcrumbs and error strings, and a filename like `SMITH_JOHN_20240115.dcm` is a PHI disclosure even when no pixel data moves. The VolView entry claimed a flat "Data stays client-side" — corrected to something accurate.

## The four DICOM-specific risks in the note

1. **Burned-in pixel PHI can't be eyeballed** the way a `PID` segment can — it's in the pixels, private tags, and SR content.
2. **Filenames leak** through crash reporting.
3. **"Client-side" stops being true at the codec boundary** — JPEG 2000 / JPEG-LS are painful in-browser, so some viewers round-trip to a server to transcode. Cross-linked to the existing transfer-syntax note.
4. **The URL bar is riskier than the file picker** — pointing a hosted viewer at your DICOMweb endpoint hands over the archive and the credentials.

All three cross-reference anchors verified against the heading list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xs8wWrAJCALFQn8CSmcWuU